### PR TITLE
Add KafkaConsumer component

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,6 +1,7 @@
 (ns user
   (:require clojure.tools.namespace.repl
             [com.stuartsierra.component.repl :as repl :refer [reset set-init]]
+            [common-clj.json :refer [json->string]]
             [java-time :refer [instant local-date local-date-time local-time]]))
 
 ;; Configure the printer

--- a/resources/data_readers.clj
+++ b/resources/data_readers.clj
@@ -3,4 +3,5 @@
  local-time      java-time/local-time
  utc             java-time/instant
  epoch           java-time/instant
- instant         java-time/instant}
+ instant         java-time/instant
+ json            common-clj.json/json->string}

--- a/src/common_clj/http_server/http_server.clj
+++ b/src/common_clj/http_server/http_server.clj
@@ -21,9 +21,9 @@
     true             (update ::http/interceptors #(cons (i-ctx/context-initializer component) %))))
 
 (defn- build-service-map [{:keys [config overrides] :as component}]
-  (let [env                                    (config-protocol/get-env config)
+  (let [env                                       (config-protocol/get-env config)
         {:keys [http-server/port] :as config-map} (config-protocol/get-config config)
-        {:keys [service-map]} overrides]
+        {:keys [service-map]}                     overrides]
     (assert-config config-map)
     (build-base-interceptors
      (merge
@@ -32,7 +32,7 @@
        ::http/host   "0.0.0.0"
        ::http/join?  false
        ::http/routes (->pedestal-routes component)
-       :env         env}
+       :env          env}
       service-map)
      component)))
 

--- a/src/common_clj/kafka/consumer/consumer.clj
+++ b/src/common_clj/kafka/consumer/consumer.clj
@@ -1,0 +1,52 @@
+(ns common-clj.kafka.consumer.consumer
+  (:require [com.stuartsierra.component :as component]
+            [common-clj.config.protocol :as conf-pro]
+            [common-clj.kafka.consumer.interceptors.coercer :as i-coercer]
+            [common-clj.kafka.consumer.interceptors.consumer-loop :as i-loop]
+            [common-clj.kafka.consumer.interceptors.handler :as i-handler]
+            [common-clj.kafka.consumer.interceptors.json-deserializer :as i-json]
+            [common-clj.kafka.consumer.interceptors.kafka-client :as i-kafka-client]
+            [common-clj.kafka.consumer.interceptors.mock-consumer-loop :as i-mock-loop]
+            [common-clj.kafka.consumer.interceptors.mock-kafka-client :as i-mock-kafka-client]
+            [common-clj.kafka.consumer.interceptors.subscriber :as i-subscriber]
+            [io.pedestal.interceptor.chain :as chain]
+            [schema.core :as s]))
+
+(def default-interceptors
+  [i-json/json-deserializer
+   i-coercer/coercer
+   i-handler/handler])
+
+(def build-interceptors (constantly default-interceptors))
+
+(def test-interceptors
+  [i-mock-kafka-client/mock-kafka-client i-mock-loop/mock-consumer-loop])
+
+(defn build-start-interceptors [env]
+  (cond->> [i-kafka-client/kafka-client i-subscriber/subscriber i-loop/consumer-loop]
+    (= env :test) (concat test-interceptors)))
+
+(defn assert-deps [components deps]
+  (run! #(assert (% components) (str "Missing dependency " %)) deps))
+
+(s/defrecord KafkaConsumer [topics]
+  component/Lifecycle
+  (start [{:keys [config producer] :as component}]
+    (assert-deps component [:config :producer])
+    (let [env                    (conf-pro/get-env config)
+          config                 (conf-pro/get-config config)
+          start-interceptors     (build-start-interceptors env)
+          consume-interceptors   (build-interceptors env)
+          context                {:config               config
+                                  :topics               topics
+                                  :consume-interceptors consume-interceptors
+                                  :components           component}
+          {:keys [kafka-client]} (chain/execute context start-interceptors)]
+      (assoc component :kafka-client kafka-client)))
+
+  (stop [{:keys [kafka-client] :as component}]
+    (.close kafka-client)
+    (dissoc component :kafka-client)))
+
+(defn new-consumer [topics]
+  (map->KafkaConsumer {:topics topics}))

--- a/src/common_clj/kafka/consumer/interceptors/coercer.clj
+++ b/src/common_clj/kafka/consumer/interceptors/coercer.clj
@@ -1,0 +1,21 @@
+(ns common-clj.kafka.consumer.interceptors.coercer
+  (:require [common-clj.coercion :as coercion]
+            [common-clj.kafka.consumer.interceptors.helpers :refer [match-topic? parse-overrides]]
+            [io.pedestal.interceptor :as interceptor]))
+
+(def default-coercers coercion/default-coercion-map)
+
+(def default-values
+  {:coercers default-coercers})
+
+(def coercer
+  (interceptor/interceptor
+   {:name ::coercer
+    :enter
+    (fn [{:keys [topics message record] :as context}]
+      (let [topic                              (ffirst (filter (match-topic? record) topics))
+            {:keys [schema]}                   (topics topic)
+            {:keys [coercers extend-coercion]} (parse-overrides context :coercer default-values)
+            coercers                           (merge coercers extend-coercion)
+            coerced-msg                        (coercion/coerce schema message coercers)]
+        (assoc context :message coerced-msg)))}))

--- a/src/common_clj/kafka/consumer/interceptors/coercer_test.clj
+++ b/src/common_clj/kafka/consumer/interceptors/coercer_test.clj
@@ -1,0 +1,56 @@
+(ns common-clj.kafka.consumer.interceptors.coercer-test
+  (:require [clojure.test :refer [is testing]]
+            [common-clj.clojure-test-helpers.core :refer [deftest]]
+            [common-clj.coercion :refer [local-date-matcher]]
+            [common-clj.kafka.consumer.interceptors.coercer :as nut]
+            [common-clj.schema.core :as cs]
+            [io.pedestal.interceptor.chain :as chain]
+            [schema.core :as s])
+  (:import clojure.lang.ExceptionInfo
+           org.apache.kafka.clients.consumer.ConsumerRecord))
+
+(def Schema
+  {:name          s/Str
+   :date-of-birth cs/LocalDate})
+
+(def context
+  {:topics
+   {:topic/a
+    {:topic  "TOPIC_A"
+     :schema Schema}}
+
+   :record (new ConsumerRecord "TOPIC_A" 0 0 0 #json {"name"          "John Doe"
+                                                      "date-of-birth" "1995-02-08"})
+
+   :message
+   {:name          "John Doe"
+    :date-of-birth "1995-02-08"}})
+
+(deftest coercer
+  (testing "coerce valid response"
+    (is (= {:name          "John Doe"
+            :date-of-birth #local-date "1995-02-08"}
+           (get-in (chain/execute context [nut/coercer])
+                   [:message]))))
+
+  (testing "throws when invalid response"
+    (let [context (assoc-in context [:message :date-of-birth] "not a local date")]
+      (is (thrown? ExceptionInfo
+                   (chain/execute context [nut/coercer])))))
+
+  (testing "override :coercers"
+    (let [custom-coercers {} ; empty, doesn't know how to coerce cs/LocalDate
+          context         (assoc-in context [:overrides :coercer :coercers] custom-coercers)]
+      (is (thrown? ExceptionInfo
+                   (chain/execute context [nut/coercer])))))
+
+  (testing "override :extension - extends coercion map"
+    (let [custom-coercers {}
+          extension       {cs/LocalDate local-date-matcher} ; adds cs/LocalDate to coercion map
+          context         (-> context
+                              (assoc-in [:overrides :coercer :coercers] custom-coercers)
+                              (assoc-in [:overrides :coercer :extend-coercion] extension))]
+      (is (= {:name          "John Doe"
+              :date-of-birth #local-date "1995-02-08"}
+             (get-in (chain/execute context [nut/coercer])
+                     [:message]))))))

--- a/src/common_clj/kafka/consumer/interceptors/consumer_loop.clj
+++ b/src/common_clj/kafka/consumer/interceptors/consumer_loop.clj
@@ -1,0 +1,24 @@
+(ns common-clj.kafka.consumer.interceptors.consumer-loop
+  (:require [io.pedestal.interceptor :as interceptor]
+            [io.pedestal.interceptor.chain :as chain]))
+
+(defn clear-pedestal-keys [context]
+  (apply dissoc context [:io.pedestal.interceptor.chain/execution-id
+                         :io.pedestal.interceptor.chain/queue
+                         :io.pedestal.interceptor.chain/stack]))
+
+(def consumer-loop
+  (interceptor/interceptor
+   {:name  ::consumer-loop
+    :enter
+    (fn [{:keys [kafka-client consume-interceptors] :as context}]
+      (future
+        (try
+          (while true
+            (let [records (seq (.poll kafka-client Long/MAX_VALUE))]
+              (doseq [record records]
+                (let [initial-context (-> context (assoc :record record) clear-pedestal-keys)]
+                  (chain/execute initial-context consume-interceptors)))))
+          (catch Exception _
+            (.close kafka-client))))
+      context)}))

--- a/src/common_clj/kafka/consumer/interceptors/handler.clj
+++ b/src/common_clj/kafka/consumer/interceptors/handler.clj
@@ -1,0 +1,11 @@
+(ns common-clj.kafka.consumer.interceptors.handler
+  (:require [common-clj.kafka.consumer.interceptors.helpers :refer [match-topic?]]
+            [io.pedestal.interceptor :as interceptor]))
+
+(def handler
+  (interceptor/interceptor
+   {:name  ::handler
+    :enter (fn [{:keys [message record topics components]}]
+             (let [topic     (ffirst (filter (match-topic? record) topics))
+                   handle-fn (:handler (topics topic))]
+               (handle-fn message components)))}))

--- a/src/common_clj/kafka/consumer/interceptors/helpers.clj
+++ b/src/common_clj/kafka/consumer/interceptors/helpers.clj
@@ -1,0 +1,7 @@
+(ns common-clj.kafka.consumer.interceptors.helpers)
+
+(defn parse-overrides [{:keys [overrides]} k default]
+  (merge default (k overrides)))
+
+(defn match-topic? [record]
+  (fn [[_ {:keys [topic]}]] (= topic (.topic record))))

--- a/src/common_clj/kafka/consumer/interceptors/json_deserializer.clj
+++ b/src/common_clj/kafka/consumer/interceptors/json_deserializer.clj
@@ -1,0 +1,31 @@
+(ns common-clj.kafka.consumer.interceptors.json-deserializer
+  (:require [cheshire.core :refer [parse-string]]
+            [common-clj.misc :as misc]
+            [io.pedestal.interceptor :as interceptor]))
+
+(defn- special-keys-fn [special-keys]
+  (fn [s] (or (special-keys s) (keyword s))))
+
+(defn default-deserialize-fn
+  ([s] (default-deserialize-fn s {}))
+  ([s extension-map]
+   (-> s
+       (parse-string (special-keys-fn extension-map))
+       misc/underscore->dash
+       misc/camelcase->dash)))
+
+(def default-values
+  {:deserialize-fn         default-deserialize-fn
+   :extend-deserialization nil})
+
+(defn parse-overrides [{:keys [overrides]} k default]
+  (merge default (k overrides)))
+
+(def json-deserializer
+  (interceptor/interceptor
+   {:name  ::json-deserializer
+    :enter (fn [{:keys [record] :as context}]
+             (let [{:keys [deserialize-fn extend-deserialization]} (parse-overrides context :json-deserializer default-values)
+                   deserialize-fn (if (nil? extend-deserialization) deserialize-fn #(deserialize-fn % extend-deserialization))
+                   deserialized    (deserialize-fn (.value record))]
+               (assoc context :message deserialized)))}))

--- a/src/common_clj/kafka/consumer/interceptors/kafka_client.clj
+++ b/src/common_clj/kafka/consumer/interceptors/kafka_client.clj
@@ -1,0 +1,22 @@
+(ns common-clj.kafka.consumer.interceptors.kafka-client
+  (:require [clojure.string :as str]
+            [io.pedestal.interceptor :as interceptor]
+            [schema.core :as s])
+  (:import java.util.Properties
+           [org.apache.kafka.clients.consumer ConsumerConfig KafkaConsumer]
+           org.apache.kafka.common.serialization.StringDeserializer))
+
+(s/defn consumer-config [{:keys [kafka/brokers] :as config}]
+  {ConsumerConfig/BOOTSTRAP_SERVERS_CONFIG        (str/join "," brokers)
+   ConsumerConfig/GROUP_ID_CONFIG                 (name (:app/name config))
+   ConsumerConfig/KEY_DESERIALIZER_CLASS_CONFIG   (.getName StringDeserializer)
+   ConsumerConfig/VALUE_DESERIALIZER_CLASS_CONFIG (.getName StringDeserializer)})
+
+(defn- ->props [config]
+  (doto (Properties.) (.putAll (consumer-config config))))
+
+(def kafka-client
+  (interceptor/interceptor
+   {:name  ::kafka-client
+    :enter (fn [{:keys [config] :as context}]
+             (assoc context :kafka-client (new KafkaConsumer (->props config))))}))

--- a/src/common_clj/kafka/consumer/interceptors/mock_consumer_loop.clj
+++ b/src/common_clj/kafka/consumer/interceptors/mock_consumer_loop.clj
@@ -1,0 +1,47 @@
+(ns common-clj.kafka.consumer.interceptors.mock-consumer-loop
+  (:require [io.pedestal.interceptor :as interceptor]
+            [io.pedestal.interceptor.chain :as chain])
+  (:import org.apache.kafka.common.TopicPartition))
+
+(defn- add-records! [records {:keys [kafka-client]}]
+  (let [partitions (map #(new TopicPartition (.topic %) 0) records)]
+    (.rebalance kafka-client partitions)
+    (.updateBeginningOffsets kafka-client (reduce (fn [acc p] (assoc acc p 0)) {} partitions))
+    (.seekToBeginning kafka-client partitions)
+    (doseq [record records] (.addRecord kafka-client record))))
+
+(defn clear-pedestal-keys [context]
+  (apply dissoc context [:io.pedestal.interceptor.chain/execution-id
+                         :io.pedestal.interceptor.chain/queue
+                         :io.pedestal.interceptor.chain/stack]))
+
+(defn- poll-and-consume! [{:keys [kafka-client consume-interceptors] :as context}]
+  (let [records (seq (.poll kafka-client Long/MAX_VALUE))]
+    (doseq [record records]
+      (let [initial-context (-> context (assoc :record record) clear-pedestal-keys)]
+        (chain/execute initial-context consume-interceptors)))))
+
+(defn not-in-coll? [coll] (fn [v] (nil? (first (filter #(= v %) coll)))))
+
+(defn- new-records [records-before records-after]
+  (filter (not-in-coll? records-before) records-after))
+
+(defn- watcher [context]
+  (fn [_ _ old-state new-state]
+    (let [records (new-records (:records old-state) (:records new-state))]
+      (add-records! records context)
+      (poll-and-consume! context))))
+
+(def i-consumer-loop
+  :common-clj.kafka.consumer.interceptors.consumer-loop/consumer-loop)
+
+(def mock-consumer-loop
+  (interceptor/interceptor
+   {:name  ::mock-consumer-loop
+    :enter (fn [{:keys [:io.pedestal.interceptor.chain/queue components] :as context}]
+             (let [produced-records (-> components :producer :produced-records)
+                   modified-queue (->> queue
+                                       (remove #(= i-consumer-loop (:name %)))
+                                       (into clojure.lang.PersistentQueue/EMPTY))]
+               (add-watch produced-records :produced-records (watcher context))
+               (assoc context :io.pedestal.interceptor.chain/queue modified-queue)))}))

--- a/src/common_clj/kafka/consumer/interceptors/mock_kafka_client.clj
+++ b/src/common_clj/kafka/consumer/interceptors/mock_kafka_client.clj
@@ -1,0 +1,17 @@
+(ns common-clj.kafka.consumer.interceptors.mock-kafka-client
+  (:require [io.pedestal.interceptor :as interceptor])
+  (:import [org.apache.kafka.clients.consumer MockConsumer OffsetResetStrategy]))
+
+(def i-kafka-client
+  :common-clj.kafka.consumer.interceptors.kafka-client/kafka-client)
+
+(def mock-kafka-client
+  (interceptor/interceptor
+   {:name  ::mock-kafka-client
+    :enter (fn [{:keys [:io.pedestal.interceptor.chain/queue] :as context}]
+             (let [modified-queue (->> queue
+                                       (remove #(= i-kafka-client (:name %)))
+                                       (into clojure.lang.PersistentQueue/EMPTY))]
+               (-> context
+                   (assoc :kafka-client (new MockConsumer OffsetResetStrategy/EARLIEST))
+                   (assoc :io.pedestal.interceptor.chain/queue modified-queue))))}))

--- a/src/common_clj/kafka/consumer/interceptors/poll.clj
+++ b/src/common_clj/kafka/consumer/interceptors/poll.clj
@@ -1,0 +1,1 @@
+(ns common-clj.kafka.consumer.interceptors.poll)

--- a/src/common_clj/kafka/consumer/interceptors/subscriber.clj
+++ b/src/common_clj/kafka/consumer/interceptors/subscriber.clj
@@ -1,0 +1,9 @@
+(ns common-clj.kafka.consumer.interceptors.subscriber
+  (:require [io.pedestal.interceptor :as interceptor]))
+
+(def subscriber
+  (interceptor/interceptor
+   {:name  ::subscriber
+    :enter (fn [{:keys [topics kafka-client] :as context}]
+             (.subscribe kafka-client (map (fn [[_ {:keys [topic]}]] topic) topics))
+             context)}))

--- a/src/common_clj/kafka/consumer/schemata.clj
+++ b/src/common_clj/kafka/consumer/schemata.clj
@@ -1,0 +1,7 @@
+(ns common-clj.kafka.consumer.schemata
+  (:require [common-clj.schema.helpers :as csh]
+            [schema.core :as s]))
+
+(def KafkaConfig
+  (csh/loose-schema
+   {:kafka/brokers [s/Str]}))

--- a/src/common_clj/kafka/producer/producer.clj
+++ b/src/common_clj/kafka/producer/producer.clj
@@ -29,7 +29,9 @@
   component/Lifecycle
   (start [{:keys [config] :as component}]
     (let [config-map (conf-pro/get-config config)]
-      (assoc component :kafka-producer (init-kafka-producer (->props config-map)))))
+      (-> component
+          (assoc :kafka-producer (init-kafka-producer (->props config-map)))
+          (assoc :produced-records (atom {:records []})))))
 
   (stop [{:keys [kafka-producer] :as component}]
     (.close kafka-producer)

--- a/src/common_clj/misc.clj
+++ b/src/common_clj/misc.clj
@@ -102,3 +102,17 @@
   [x]
   (walk/postwalk #(if (seq? %) (vec %) %)
                  x))
+
+(defn keyword->constant-case
+  "Examples:
+  :foo-bar -> FOO_BAR
+  :foo/bar -> FOO_BAR
+  :foo/bar-baz -> FOO_BAR_BAZ"
+  [k]
+  (-> k
+      str
+      str/upper-case
+      (str/replace #":" "")    ; removes :
+      (str/replace \- \_)      ; dash -> underscore
+      (str/replace \/ \_)      ; qualified keyword -> underscore      
+      ))

--- a/test/common_clj/kafka/consumer/consumer_test.clj
+++ b/test/common_clj/kafka/consumer/consumer_test.clj
@@ -1,0 +1,73 @@
+(ns common-clj.kafka.consumer.consumer-test
+  (:require [clojure.test :refer [is testing]]
+            [com.stuartsierra.component :as component]
+            [common-clj.clojure-test-helpers.core :refer [deftest]]
+            [common-clj.config.in-memory-config :as imc]
+            [common-clj.kafka.consumer.consumer :as nut]
+            [common-clj.kafka.producer.producer :as kafka-producer]
+            [common-clj.key-value-store.in-memory-key-value-store :as in-memory-kvs]
+            [common-clj.key-value-store.protocol :as kvs-pro]
+            [schema.core :as s])
+  (:import clojure.lang.ExceptionInfo
+           org.apache.kafka.clients.consumer.ConsumerRecord))
+
+(def config {:app/name      :my-app
+             :kafka/brokers ["localhost:9092"]})
+
+(def topics
+  {:topic/a
+   {:topic   "TOPIC_A"
+    :schema  {:a s/Str}
+    :handler (fn [message {:keys [key-value-store]}]
+               (kvs-pro/store! key-value-store :topic/a message))}
+
+   :topic/b
+   {:topic   "TOPIC_B"
+    :schema  {:b s/Str}
+    :handler (fn [message {:keys [key-value-store]}]
+               (kvs-pro/store! key-value-store :topic/b message))}})
+
+(def system
+  (component/system-map
+   :config          (imc/new-config config :test)
+   :key-value-store (in-memory-kvs/new-key-value-store)
+   :producer        (component/using
+                     (kafka-producer/new-producer {})
+                     [:config])
+   :consumer        (component/using
+                     (nut/new-consumer topics)
+                     [:config :key-value-store :producer])))
+
+(defn- start-consumer []
+  (component/start system))
+
+(defn- produce! [{:keys [producer]} topic msg]
+  (swap! (:produced-records producer) update :records conj (new ConsumerRecord topic 0 0 0 msg)))
+
+(defn- fetch [key-value-store topic]
+  (kvs-pro/fetch key-value-store topic))
+
+(deftest consume!
+  (testing "consumes a message from a kafka topic"
+    (let [{:keys [consumer key-value-store]} (start-consumer)]
+
+      (produce! consumer "TOPIC_A" #json {"a" "hello"})
+
+      (is (= {:a "hello"} (fetch key-value-store :topic/a)))
+      (is (= nil (fetch key-value-store :topic/b)))
+      (is (= nil (fetch key-value-store :topic/c)))
+
+      (produce! consumer "TOPIC_B" #json {"b" "hello"})
+
+      (is (= {:b "hello"} (fetch key-value-store :topic/b)))))
+
+  (testing "closes consumer on component/stop"
+    (let [{:keys [consumer] :as system} (start-consumer)]
+      (component/stop system)
+      (is (-> consumer :kafka-client .closed))))
+
+  (testing "when message does not conform to schema throws error"
+    (let [{:keys [consumer]} (start-consumer)]
+
+      (is (thrown-with-msg? ExceptionInfo #"Could not coerce value to schema"
+                            (produce! consumer "TOPIC_A" #json {"b" "hello"}))))))

--- a/test/common_clj/kafka/consumer/interceptors/consumer_loop_test.clj
+++ b/test/common_clj/kafka/consumer/interceptors/consumer_loop_test.clj
@@ -1,0 +1,40 @@
+(ns common-clj.kafka.consumer.interceptors.consumer-loop-test
+  (:require [clojure.test :refer [is testing]]
+            [common-clj.clojure-test-helpers.core :refer [deftest]]
+            [common-clj.kafka.consumer.interceptors.consumer-loop :as nut]
+            [io.pedestal.interceptor :as interceptor]
+            [io.pedestal.interceptor.chain :as chain])
+  (:import [org.apache.kafka.clients.consumer ConsumerRecord MockConsumer OffsetResetStrategy]
+           org.apache.kafka.common.TopicPartition))
+
+(def partition-0 (new TopicPartition "TOPIC_A" 0))
+(def first-message "hello")
+(def second-message "bye")
+
+(def dummy-interceptor
+  (interceptor/interceptor
+   {:name ::dummy
+    :enter (fn [{:keys [record consumed-messages] :as context}]
+             (swap! consumed-messages update (.topic record) conj (.value record))
+             context)}))
+
+(defn context []
+  {:kafka-client
+   (doto (new MockConsumer OffsetResetStrategy/EARLIEST)
+     (.subscribe ["TOPIC_A"])
+     (.rebalance [partition-0])
+     (.updateBeginningOffsets {partition-0 0})
+     (.seek partition-0 0)
+     (.addRecord (new ConsumerRecord "TOPIC_A" 0 0 0 first-message))
+     (.addRecord (new ConsumerRecord "TOPIC_A" 0 1 0 second-message)))
+
+   :consume-interceptors [dummy-interceptor]
+
+   :consumed-messages (atom {"TOPIC_A" []})})
+
+(deftest consumer-loop
+  (testing "polls records from broker and consumes them"
+    (let [{:keys [consumed-messages]} (chain/execute (context) [nut/consumer-loop])]
+      (Thread/sleep 10) ; give some time for the messages to be consumed
+      (is (= ["hello" "bye"]
+             (-> consumed-messages deref (get "TOPIC_A")))))))

--- a/test/common_clj/kafka/consumer/interceptors/handler_test.clj
+++ b/test/common_clj/kafka/consumer/interceptors/handler_test.clj
@@ -1,0 +1,35 @@
+(ns common-clj.kafka.consumer.interceptors.handler-test
+  (:require [clojure.test :refer [is testing]]
+            [com.stuartsierra.component :as component]
+            [common-clj.clojure-test-helpers.core :refer [deftest]]
+            [common-clj.kafka.consumer.interceptors.handler :as nut]
+            [common-clj.key-value-store.in-memory-key-value-store :as in-memory-kvs]
+            [common-clj.key-value-store.protocol :as kvs-pro]
+            [io.pedestal.interceptor.chain :as chain]
+            [schema.core :as s])
+  (:import org.apache.kafka.clients.consumer.ConsumerRecord))
+
+(def hello (new ConsumerRecord "TOPIC_A" 0 0 0 #json {"a" "hello"}))
+
+(defn ->context []
+  {:message {:a "hello"}
+
+   :record hello
+
+   :topics
+   {:topic/a
+    {:topic   "TOPIC_A"
+     :schema  {:a s/Str}
+     :handler (fn [message {:keys [db]}]
+                (kvs-pro/store! db :topic/a message))}}
+
+   :components
+   {:db (component/start (in-memory-kvs/new-key-value-store))}})
+
+(deftest handler
+  (testing "calls the handler fn according to record topic"
+    (let [{{:keys [db]} :components :as context} (->context)]
+      (chain/execute context [nut/handler])
+
+      (is (= {:a "hello"}
+             (kvs-pro/fetch db :topic/a))))))

--- a/test/common_clj/kafka/consumer/interceptors/json_deserializer_test.clj
+++ b/test/common_clj/kafka/consumer/interceptors/json_deserializer_test.clj
@@ -1,0 +1,49 @@
+(ns common-clj.kafka.consumer.interceptors.json-deserializer-test
+  (:require [cheshire.core :refer [parse-string]]
+            [clojure.test :refer [is testing]]
+            [common-clj.clojure-test-helpers.core :refer [deftest]]
+            [common-clj.kafka.consumer.interceptors.json-deserializer :as nut]
+            [io.pedestal.interceptor.chain :as chain])
+  (:import org.apache.kafka.clients.consumer.ConsumerRecord))
+
+(defn context [message]
+  {:record (new ConsumerRecord "TOPIC" 0 0 0 message)})
+
+(deftest json-deserializer
+  (testing "parses kafka record as json"
+    (is (= {:a "hello"}
+           (get-in
+            (chain/execute (context #json {"a" "hello"}) [nut/json-deserializer])
+            [:message]))))
+
+  (testing "converts underscore to dash"
+    (is (= {:my-message "hello"}
+           (get-in
+            (chain/execute (context #json {"my_message" "hello"}) [nut/json-deserializer])
+            [:message]))))
+
+  (testing "converts camelcase to dash"
+    (is (= {:my-message "hello"}
+           (get-in
+            (chain/execute (context #json {"myMessage" "hello"}) [nut/json-deserializer])
+            [:message]))))
+
+  (testing "override deserialize-fn"
+    (let [deserialize-fn #(parse-string % false) ; dont keywordize keys
+          ctx            (assoc-in (context #json {"a" "hello"})
+                                   [:overrides :json-deserializer :deserialize-fn]
+                                   deserialize-fn)]
+      (is (= {"a" "hello"}
+             (get-in
+              (chain/execute ctx [nut/json-deserializer])
+              [:message])))))
+
+  (testing "override extension"
+    (let [special-keys {"a" :bla}
+          ctx          (assoc-in (context #json {"a" "hello"})
+                                 [:overrides :json-deserializer :extend-deserialization]
+                                 special-keys)]
+      (is (= {:bla "hello"}
+             (get-in
+              (chain/execute ctx [nut/json-deserializer])
+              [:message]))))))

--- a/test/common_clj/kafka/consumer/interceptors/kafka_client_test.clj
+++ b/test/common_clj/kafka/consumer/interceptors/kafka_client_test.clj
@@ -1,0 +1,32 @@
+(ns common-clj.kafka.consumer.interceptors.kafka-client-test
+  (:require [clojure.test :refer [is testing]]
+            [common-clj.clojure-test-helpers.core :refer [deftest]]
+            [common-clj.kafka.consumer.interceptors.kafka-client :as nut]
+            [io.pedestal.interceptor.chain :as chain])
+  (:import [org.apache.kafka.clients.consumer ConsumerConfig KafkaConsumer]))
+
+(def config
+  {:kafka/brokers ["localhost:9092" "localhost:9091"]
+   :app/name      :my-app})
+
+(def context
+  {:config config})
+
+(deftest consumer-config
+  (testing "kafka brokers"
+    (is (= "localhost:9092,localhost:9091"
+           (get-in
+            (nut/consumer-config config)
+            [ConsumerConfig/BOOTSTRAP_SERVERS_CONFIG]))))
+
+  (testing "consumer group"
+    (is (= "my-app"
+           (get-in
+            (nut/consumer-config config)
+            [ConsumerConfig/GROUP_ID_CONFIG])))))
+
+(deftest kafka-client
+  (testing "instantiates new kafka client"
+    (let [{:keys [kafka-client]} (chain/execute context [nut/kafka-client])]
+      (is (instance? KafkaConsumer kafka-client))
+      (.close kafka-client))))

--- a/test/common_clj/kafka/consumer/interceptors/mock_consumer_loop_test.clj
+++ b/test/common_clj/kafka/consumer/interceptors/mock_consumer_loop_test.clj
@@ -1,0 +1,50 @@
+(ns common-clj.kafka.consumer.interceptors.mock-consumer-loop-test
+  (:require [clojure.test :refer [is testing]]
+            [common-clj.clojure-test-helpers.core :refer [deftest]]
+            [common-clj.kafka.consumer.interceptors.mock-consumer-loop :as nut]
+            [io.pedestal.interceptor :as interceptor]
+            [io.pedestal.interceptor.chain :as chain])
+  (:import [org.apache.kafka.clients.consumer ConsumerRecord MockConsumer OffsetResetStrategy]))
+
+(def dummy-interceptor
+  (interceptor/interceptor
+   {:name ::dummy
+    :enter (fn [{:keys [record consumed-messages] :as context}]
+             (swap! consumed-messages update (.topic record) conj (.value record))
+             context)}))
+
+(defn context []
+  {:kafka-client         (doto (new MockConsumer OffsetResetStrategy/EARLIEST)
+                           (.subscribe ["TOPIC_A"]))
+   :consume-interceptors [dummy-interceptor]
+   :consumed-messages    (atom {"TOPIC_A" []})
+   :components           {:producer {:produced-records (atom {:records []})}}})
+
+(def hello (new ConsumerRecord "TOPIC_A" 0 0 0 "hello"))
+(def bye (new ConsumerRecord "TOPIC_A" 0 1 0 "bye"))
+
+(defn produce-record! [record]
+  (interceptor/interceptor
+   {:name ::produce-record
+    :enter (fn [{{:keys [producer]} :components :as context}]
+             (swap! (:produced-records producer) update :records conj record)
+             context)}))
+
+(def fake-consumer-loop
+  (interceptor/interceptor
+   {:name :common-clj.kafka.consumer.interceptors.consumer-loop/consumer-loop
+    :enter (fn [{:keys [consumed-messages] :as context}]
+             (swap! consumed-messages update "TOPIC_A" conj "message")
+             context)}))
+
+(deftest mock-consumer-loop
+  (testing "polls records from produced-messages and consumes them"
+    (let [{:keys [consumed-messages]} (chain/execute (context) [nut/mock-consumer-loop
+                                                                (produce-record! hello)
+                                                                (produce-record! bye)])]
+      (is (= ["hello" "bye"]
+             (-> consumed-messages deref (get "TOPIC_A"))))))
+  (testing "removes consumer loop from the interceptor queue"
+    (let [{:keys [consumed-messages]} (chain/execute (context) [nut/mock-consumer-loop
+                                                                fake-consumer-loop])]
+      (is (-> consumed-messages deref (get "TOPIC_A") empty?)))))

--- a/test/common_clj/kafka/consumer/interceptors/mock_kafka_client_test.clj
+++ b/test/common_clj/kafka/consumer/interceptors/mock_kafka_client_test.clj
@@ -1,0 +1,12 @@
+(ns common-clj.kafka.consumer.interceptors.mock-kafka-client-test
+  (:require [clojure.test :refer [is testing]]
+            [common-clj.clojure-test-helpers.core :refer [deftest]]
+            [common-clj.kafka.consumer.interceptors.kafka-client :as i-kafka-client]
+            [common-clj.kafka.consumer.interceptors.mock-kafka-client :as nut]
+            [io.pedestal.interceptor.chain :as chain])
+  (:import org.apache.kafka.clients.consumer.MockConsumer))
+
+(deftest mock-kafka-client
+  (testing "instantiates MockConsumer and removes kafka-client from queue"
+    (let [{:keys [kafka-client]} (chain/execute {} [nut/mock-kafka-client i-kafka-client/kafka-client])]
+      (is (instance? MockConsumer kafka-client)))))

--- a/test/common_clj/kafka/consumer/interceptors/subscriber_test.clj
+++ b/test/common_clj/kafka/consumer/interceptors/subscriber_test.clj
@@ -1,0 +1,19 @@
+(ns common-clj.kafka.consumer.interceptors.subscriber-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [common-clj.kafka.consumer.interceptors.subscriber :as nut]
+            [io.pedestal.interceptor.chain :as chain])
+  (:import [org.apache.kafka.clients.consumer MockConsumer OffsetResetStrategy]))
+
+(def topics
+  {:topic-a {:topic "TOPIC_A"}
+   :topic-b {:topic "TOPIC_B"}})
+
+(def context
+  {:topics       topics
+   :kafka-client (new MockConsumer OffsetResetStrategy/LATEST)})
+
+(deftest subscriber
+  (testing "subscribes to given topics"
+    (let [{:keys [kafka-client]} (chain/execute context [nut/subscriber])]
+      (is (= #{"TOPIC_A" "TOPIC_B"}
+             (.subscription kafka-client))))))

--- a/test/common_clj/key_value_store/in_memory_key_value_store.clj
+++ b/test/common_clj/key_value_store/in_memory_key_value_store.clj
@@ -1,0 +1,21 @@
+(ns common-clj.key-value-store.in-memory-key-value-store
+  (:require [com.stuartsierra.component :as component]
+            [common-clj.key-value-store.protocol :as kvs-pro]))
+
+(defrecord InMemoryKeyValueStore []
+  component/Lifecycle
+  (start [component]
+    (assoc component :store (atom {})))
+
+  (stop [component]
+    (dissoc component :store))
+
+  kvs-pro/KeyValueStore
+  (fetch [{:keys [store]} k]
+    (-> store deref k))
+
+  (store! [{:keys [store]} k v]
+    (swap! store assoc k v)))
+
+(defn new-key-value-store []
+  (map->InMemoryKeyValueStore {}))

--- a/test/common_clj/key_value_store/protocol.clj
+++ b/test/common_clj/key_value_store/protocol.clj
@@ -1,0 +1,6 @@
+(ns common-clj.key-value-store.protocol)
+
+(defprotocol KeyValueStore
+  (fetch [component k])
+
+  (store! [component k v]))


### PR DESCRIPTION
This commit adds a Kafka Consumer that implements Stuart Sierra's component and provides high-level abstractions to work with in Clojure. To use this component, one must provide a valid mapping of topics and handlers like the example below:

```clj
(def consumer-topics
  {:topic-a
   {:topic   "TOPIC_A" ; this will be the name of the topic on Kafka
    :schema  SchemaA
    :handler (fn [message components] ; the handler signature takes the message and the components as parameters
               (do-some-stuff message components))}
   :topic-b
   {:topic   "TOPIC_B"
    :schema  SchemaB
    :handler (fn [message components]
               (do-some-other-cool-stuffs message components)}}})
```

And then add it to the system map like this:

```clj
(def my-system
  (component/system-map
    :config      (conf/new-config)

    :producer    (component/using
                   (kafka-producer/new-producer producer-topics)
                   [:config])

    :consumer    (component/using
                   (kafka-consumer/new-consumer consumer-topics) ; NOTE: the consumer depends on :config and :producer components
                   [:config :producer]))
```

Note that the consumer depends on both `config` and `producer` components. The dependency on producer is required because otherwise the consumer would not be able to produce deadletters in case of consumption failures. Also, for test environment the consumer listens to producer state to consume produced messages in memory.

Main features for now are:
- JSON deserialization
- Schema validation
- Components injection to handler (via `component/using` from Stuart Sierra)

In the future should add support for more data formats other than JSON.